### PR TITLE
Changes to order pages and a product page

### DIFF
--- a/KE03_INTDEV_SE_2_Base/Views/Orders/Create.cshtml
+++ b/KE03_INTDEV_SE_2_Base/Views/Orders/Create.cshtml
@@ -20,7 +20,7 @@
                 @for (int i = 0; i < Model.OrderParts.Count; i++)
                 {
                     <div class="order-part border p-2 mb-2 rounded position-relative">
-                        <button type="button" class="btn btn-sm btn-danger remove-btn" style="position: absolute; top: 5px; right: 5px;">✕</button>
+                        <button type="button" class="btn-close remove-btn position-absolute" style="top: 0.5rem; right: 0.5rem;" aria-label="Remove"></button>
                         <div class="form-group">
                             <label>Product</label>
                             <select name="OrderParts[@i].ProductId" class="form-control" asp-items="ViewBag.partId"></select>
@@ -38,13 +38,7 @@
                 <label asp-for="DeliveryOption" class="control-label"></label>
                 <select asp-for="DeliveryOption" class="form-control" asp-items="ViewBag.DeliveryOption"></select>
             </div>
-
-            <div class="form-group form-check">
-                <label class="form-check-label">
-                    <input class="form-check-input" asp-for="Delivered" /> @Html.DisplayNameFor(model => model.Delivered)
-                </label>
-            </div>
-
+            <br/>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>

--- a/KE03_INTDEV_SE_2_Base/Views/Orders/Create.cshtml
+++ b/KE03_INTDEV_SE_2_Base/Views/Orders/Create.cshtml
@@ -58,7 +58,7 @@
             const container = document.getElementById('orderPartsContainer');
             const template = `
                 <div class="order-part border p-2 mb-2 rounded position-relative">
-                    <button type="button" class="btn btn-sm btn-danger remove-btn" style="position: absolute; top: 5px; right: 5px;">✕</button>
+                    <button type="button" class="btn-close remove-btn position-absolute" style="top: 0.5rem; right: 0.5rem;" aria-label="Remove"></button>
                     <div class="form-group">
                         <label>Product</label>
                         <select name="OrderParts[${index}].ProductId" class="form-control">

--- a/KE03_INTDEV_SE_2_Base/Views/Orders/Details.cshtml
+++ b/KE03_INTDEV_SE_2_Base/Views/Orders/Details.cshtml
@@ -82,7 +82,7 @@
                 }
                 <tr>
                     <td>
-                        total price:
+                        Total:
                     </td>
                     <td></td>
                     <td></td>

--- a/KE03_INTDEV_SE_2_Base/Views/Orders/Index.cshtml
+++ b/KE03_INTDEV_SE_2_Base/Views/Orders/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 class="mb-0">@ViewData["Title"]</h2>
         <a asp-action="Create" class="btn btn-primary">
-            <i class="bi bi-plus-circle"></i> Create New Product
+            <i class="bi bi-plus-circle"></i> Create Replacement Order
         </a>
     </div>
     <div class="table-responsive">

--- a/KE03_INTDEV_SE_2_Base/Views/Products/Create.cshtml
+++ b/KE03_INTDEV_SE_2_Base/Views/Products/Create.cshtml
@@ -32,6 +32,7 @@
                 <input asp-for="ImageUrl" class="form-control" />
                 <span asp-validation-for="ImageUrl" class="text-danger"></span>
             </div>
+            <br/>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>


### PR DESCRIPTION
- Put a small piece of space between the create button for order and product
- Changed creating an order to creating a replacement order
- Removed the ability to immediately set an order to delivered, cause you first need to hand it over to the shipping company (and also you can scam people by saying its already delivered and they should pay up)
- Fixed the remove button for product removing on order creation overlapping with the selection bar.
- Changed total price to "Total" :P